### PR TITLE
Rake task logs

### DIFF
--- a/app/controllers/rake_ui/rake_task_logs_controller.rb
+++ b/app/controllers/rake_ui/rake_task_logs_controller.rb
@@ -1,0 +1,23 @@
+module RakeUi
+  class RakeTaskLogsController < ApplicationController
+    def index
+      @rake_task_logs = RakeUi::RakeTaskLog.all.sort_by(&:id)
+
+      respond_to do |format|
+        format.html
+        format.json
+      end
+    end
+
+    def show
+      @rake_task_log = RakeUi::RakeTaskLog.find_by_id(params[:id])
+      @rake_task_log_content = @rake_task_log.file_contents.gsub("\n", "<br />")
+      @rake_task_log_content_url = rake_task_logs_path(@rake_task_log.id, format: :json)
+
+      respond_to do |format|
+        format.html
+        format.json
+      end
+    end
+  end
+end

--- a/app/controllers/rake_ui/rake_task_logs_controller.rb
+++ b/app/controllers/rake_ui/rake_task_logs_controller.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 module RakeUi
   class RakeTaskLogsController < ApplicationController
     def index
@@ -12,7 +14,8 @@ module RakeUi
     def show
       @rake_task_log = RakeUi::RakeTaskLog.find_by_id(params[:id])
       @rake_task_log_content = @rake_task_log.file_contents.gsub("\n", "<br />")
-      @rake_task_log_content_url = rake_task_logs_path(@rake_task_log.id, format: :json)
+
+      @rake_task_log_content_url = rake_task_log_path(@rake_task_log.id, format: :json)
 
       respond_to do |format|
         format.html

--- a/app/controllers/rake_ui/rake_tasks_controller.rb
+++ b/app/controllers/rake_ui/rake_tasks_controller.rb
@@ -18,13 +18,12 @@ module RakeUi
       end
     end
 
-
     def execute
       @rake_task = RakeUi::RakeTask.find_by_id(params[:id])
 
-      @rake_task.call(args: params[:args], environment: params[:environment])
+      rake_task_log = @rake_task.call(args: params[:args], environment: params[:environment])
 
-      redirect_to rake_task_path @rake_task.id
+      redirect_to rake_task_log_path rake_task_log.id
     end
   end
 end

--- a/app/models/rake_ui/rake_task.rb
+++ b/app/models/rake_ui/rake_task.rb
@@ -65,7 +65,7 @@ module RakeUi
     def call(args: nil, environment: nil)
       rake_command = build_rake_command(args: args, environment: environment)
 
-      raker_log = RakeUi::RakeTaskLog.new_for_command(
+      raker_log = RakeUi::RakeTaskLog.build_new_for_command(
         name: name,
         args: args,
         environment: environment,

--- a/app/models/rake_ui/rake_task.rb
+++ b/app/models/rake_ui/rake_task.rb
@@ -1,5 +1,3 @@
-require 'rake'
-
 module RakeUi
   class RakeTask
     def self.load
@@ -61,7 +59,6 @@ module RakeUi
       # end
     end
 
-    require 'open3'
     def call(args: nil, environment: nil)
       rake_command = build_rake_command(args: args, environment: environment)
 

--- a/app/models/rake_ui/rake_task_log.rb
+++ b/app/models/rake_ui/rake_task_log.rb
@@ -1,0 +1,80 @@
+module RakeUi
+  class RakeTaskLog < OpenStruct
+    # year-month-day-hour(24hour time)-minute-second-utc
+    ID_DATE_FORMAT = "%Y-%m-%d-%H-%M-%S%z"
+    REPOSITORY_DIR = Rails.root.join('tmp', 'rake_ui')
+    FILE_DELIMITER = '____'
+
+    def self.truncate
+      FileUtils.rm_rf(Dir.glob(REPOSITORY_DIR.to_s + '/*'))
+    end
+
+    def self.build_from_file(log_file_name)
+      # date, task = log_file_name.split(FILE_DELIMITER)
+
+      new(
+        id: log_file_name.gsub('.txt', ''),
+        log_file_name: log_file_name,
+        log_file_full_path: Rails.root.join(REPOSITORY_DIR, log_file_name).to_s
+      )
+    end
+
+    def self.build_new_for_command(name:, args: nil, environment: nil,rake_definition_file:, rake_command:, raker_id:)
+      id = "#{Time.now.strftime(ID_DATE_FORMAT)}#{FILE_DELIMITER}#{raker_id}"
+      log_file_name = "#{id}.txt"
+      log_file_full_path = Rails.root.join('tmp', 'rake_ui', log_file_name).to_s
+
+      File.open(log_file_full_path, 'w+') do |f|
+        f.puts "id: #{id}"
+        f.puts "name: #{name}"
+        f.puts "args: #{args}"
+        f.puts "environment: #{environment}"
+        f.puts "rake_command: #{rake_command}"
+        f.puts "rake_definition_file #{rake_definition_file}"
+        f.puts "log_file_name: #{log_file_name}"
+        f.puts "log_file_full_path: #{log_file_full_path}"
+
+        f.puts "-------------------------------"
+        f.puts " INVOKED RAKE TASK OUTPUT BELOW"
+        f.puts "-------------------------------"
+      end
+
+      new(id: id,
+          name: name,
+          args: args,
+          environment: environment,
+          rake_command: rake_command,
+          rake_definition_file: rake_definition_file,
+          log_file_name: log_file_name,
+          log_file_full_path: log_file_full_path)
+    end
+
+    def self.all
+      Dir.entries(REPOSITORY_DIR).reject do |file|
+        file == '.' || file == '..'
+      end.map do |log|
+        RakeUi::RakeTaskLog.build_from_file(log)
+      end
+    end
+
+    def self.find_by_id(id)
+      all.find do |a|
+        a.id == id || a.id == CGI.escape(id)
+      end
+    end
+
+    def self.for(rake_ui_rake_task)
+      all.select do |history|
+        history.id == rake_ui_rake_task.id
+      end
+    end
+
+    def rake_command_with_logging
+      "#{rake_command} 2>&1 >> #{log_file_full_path}"
+    end
+
+    def file_contents
+      @file_contents ||= File.read(log_file_full_path)
+    end
+  end
+end

--- a/app/views/layouts/rake_ui/application.html.erb
+++ b/app/views/layouts/rake_ui/application.html.erb
@@ -8,8 +8,9 @@
   <%= stylesheet_link_tag "rake_ui/application", media: "all" %>
 </head>
 <body>
+  <%= link_to "Tasks", rake_tasks_path %>
+  <%= link_to "Last Ran", rake_task_logs_path %>
 
-<%= yield %>
-
+  <%= yield %>
 </body>
 </html>

--- a/app/views/rake_ui/rake_task_logs/_rake_task_log.json.jbuilder
+++ b/app/views/rake_ui/rake_task_logs/_rake_task_log.json.jbuilder
@@ -1,0 +1,9 @@
+json.extract! rake_task_log,
+              :id,
+              :name,
+              :args,
+              :environment,
+              :rake_command,
+              :rake_definition_file,
+              :log_file_name,
+              :log_file_full_path

--- a/app/views/rake_ui/rake_task_logs/index.html.erb
+++ b/app/views/rake_ui/rake_task_logs/index.html.erb
@@ -27,6 +27,3 @@
   <% end %>
   </tbody>
 </table>
-
-<br>
-

--- a/app/views/rake_ui/rake_task_logs/index.html.erb
+++ b/app/views/rake_ui/rake_task_logs/index.html.erb
@@ -1,0 +1,32 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Status</h1>
+
+<hr >
+
+<table>
+  <thead>
+  <tr>
+    <th colspan="3"></th>
+  </tr>
+  </thead>
+
+  <tbody>
+  <tr>
+    <td>id</td>
+    <td>name</td>
+    <td>date</td>
+  </tr>
+  <% @rake_task_logs.each do |rake_task_log| %>
+    <tr>
+      <td><%= link_to rake_task_log.id, rake_task_log_path(rake_task_log.id) %></td>
+      <td><%= rake_task_log.id %></td>
+      <td><%= rake_task_log.name %></td>
+      <td><%= rake_task_log.date %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+
+<br>
+

--- a/app/views/rake_ui/rake_task_logs/index.json.jbuilder
+++ b/app/views/rake_ui/rake_task_logs/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.rake_task_logs do
+  json.array! @rake_task_logs, partial: 'rake_ui/rake_task_logs/rake_task_log', as: :rake_task_log
+end

--- a/app/views/rake_ui/rake_task_logs/show.html.erb
+++ b/app/views/rake_ui/rake_task_logs/show.html.erb
@@ -1,3 +1,5 @@
+<h1>Rake Task Log</h1>
+
 <div id="log_content" class="overflow-y: scroll">
   <%= @rake_task_log_content.html_safe %>
 </div>

--- a/app/views/rake_ui/rake_task_logs/show.html.erb
+++ b/app/views/rake_ui/rake_task_logs/show.html.erb
@@ -1,4 +1,3 @@
-
 <div id="log_content" class="overflow-y: scroll">
   <%= @rake_task_log_content.html_safe %>
 </div>

--- a/app/views/rake_ui/rake_task_logs/show.html.erb
+++ b/app/views/rake_ui/rake_task_logs/show.html.erb
@@ -1,0 +1,30 @@
+
+<div id="log_content" class="overflow-y: scroll">
+  <%= @rake_task_log_content.html_safe %>
+</div>
+
+<script type="application/javascript">
+  var interval;
+  var content_url = "<%= @rake_task_log_content_url %>"
+  var is_requesting = false
+
+  function replaceContent(content) {
+    document.getElementById('log_content').innerHTML = content
+  }
+
+  interval = setInterval(function () {
+    if (is_requesting) { return }
+    is_requesting = true;
+    fetch(content_url)
+      .then(function(r) { return r.json() })
+      .then(function (r) {
+        replaceContent(r.rake_task_log_content)
+        is_requesting = false
+      })
+      .catch(function(err) {
+        is_requesting = false
+        clearInterval(interval)
+        throw(err)
+      })
+  }, 500)
+</script>

--- a/app/views/rake_ui/rake_task_logs/show.json.jbuilder
+++ b/app/views/rake_ui/rake_task_logs/show.json.jbuilder
@@ -1,0 +1,3 @@
+json.rake_task_log @rake_task_log, partial: 'rake_ui/rake_task_logs/rake_task_log', as: :rake_task_log
+
+json.rake_task_log_content @rake_task_log_content

--- a/app/views/rake_ui/rake_tasks/index.html.erb
+++ b/app/views/rake_ui/rake_tasks/index.html.erb
@@ -24,7 +24,7 @@
   </tr>
   <% @rake_tasks.each do |rake_tasks| %>
     <tr>
-      <td><%= link_to rake_tasks.id, rake_tasks_path(rake_tasks.id) %></td>
+      <td><%= link_to rake_tasks.id, rake_task_path(rake_tasks.id) %></td>
       <td><%= rake_tasks.name %></td>
       <td><%= rake_tasks.name_with_args %></td>
       <td><%= rake_tasks.arg_description %></td>

--- a/app/views/rake_ui/rake_tasks/index.html.erb
+++ b/app/views/rake_ui/rake_tasks/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <h1>Rake Tasks</h1>
 
 <hr >

--- a/app/views/rake_ui/rake_tasks/show.html.erb
+++ b/app/views/rake_ui/rake_tasks/show.html.erb
@@ -1,5 +1,7 @@
+<h1>Rake Task</h1>
+
 <%= @rake_task.name %>
-<%= form_with url: rake_task_execute_path(@rake_task), method: :post do |f| %>
+<%= form_with url: rake_task_execute_path(@rake_task.id), method: :post do |f| %>
   <%= f.label :args, "Arguments, as if you were raking" %>
   <%= f.text_field :arguments %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ RakeUi::Engine.routes.draw do
   resources :rake_tasks, only: [:index, :show]
 
   post "/rake_tasks/:id/execute", to: "rake_tasks#execute", as: "rake_task_execute"
+
+  resources :rake_task_logs, only: [:index, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 RakeUi::Engine.routes.draw do
+  root to: 'rake_tasks#index'
+
   resources :rake_tasks, only: [:index, :show]
 
   post "/rake_tasks/:id/execute", to: "rake_tasks#execute", as: "rake_task_execute"

--- a/lib/rake_ui/engine.rb
+++ b/lib/rake_ui/engine.rb
@@ -1,5 +1,6 @@
 require 'rake'
 require 'fileutils'
+require 'open3'
 
 module RakeUi
   class Engine < ::Rails::Engine

--- a/lib/rake_ui/engine.rb
+++ b/lib/rake_ui/engine.rb
@@ -1,3 +1,6 @@
+require 'rake'
+require 'fileutils'
+
 module RakeUi
   class Engine < ::Rails::Engine
     isolate_namespace RakeUi

--- a/test/dummy/config.ru
+++ b/test/dummy/config.ru
@@ -3,4 +3,7 @@
 require_relative "config/environment"
 
 run Rails.application
-Rails.application.load_server
+
+if Rails.application.respond_to? :load_server
+  Rails.application.load_server
+end

--- a/test/integration/rake_task_logs_request_test.rb
+++ b/test/integration/rake_task_logs_request_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'pry'
+
 class RakeTaskLogsRequestTest < ActionDispatch::IntegrationTest
   test "index html responds successfully" do
     get '/rake-ui/rake_task_logs'

--- a/test/integration/rake_task_logs_request_test.rb
+++ b/test/integration/rake_task_logs_request_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'pry'
+class RakeTaskLogsRequestTest < ActionDispatch::IntegrationTest
+  test "index html responds successfully" do
+    get '/rake-ui/rake_task_logs'
+
+    assert_equal 200, status
+  end
+
+  test "index json responds successfully" do
+    get '/rake-ui/rake_task_logs.json'
+
+    assert_equal 200, status
+    assert_instance_of Array, json_response[:rake_task_logs]
+  end
+
+  test "show html responds with the content" do
+    log = RakeUi::RakeTaskLog.all.first
+    get "/rake-ui/rake_task_logs/#{log.id}"
+
+    assert_equal 200, status
+    assert_includes response.body, "INVOKED RAKE TASK OUTPUT BELOW"
+  end
+
+  test "show json responds with the content and task log meta" do
+    log = RakeUi::RakeTaskLog.all.first
+    get "/rake-ui/rake_task_logs/#{log.id}.json"
+
+    assert_equal 200, status
+
+    assert_equal log.id, json_response[:rake_task_log][:id]
+    assert_equal log.log_file_name, json_response[:rake_task_log][:log_file_name]
+
+    assert_includes json_response[:rake_task_log_content], log.id
+  end
+end

--- a/test/integration/rake_tasks_request_test.rb
+++ b/test/integration/rake_tasks_request_test.rb
@@ -36,7 +36,7 @@ class RakeTasksRequestTest < ActionDispatch::IntegrationTest
   test "post executes the task" do
     mock_task = Minitest::Mock.new
     def mock_task.id; "some_identifier"; end
-    mock_task.expect :call, true, [{ args: "1,2,3", environment: "FOO=bar" }]
+    mock_task.expect :call, OpenStruct.new(id: '1234_path'), [{ args: "1,2,3", environment: "FOO=bar" }]
 
     mock_find_by_id = lambda do |args|
       assert args, "some_identifier"
@@ -47,6 +47,8 @@ class RakeTasksRequestTest < ActionDispatch::IntegrationTest
     RakeUi::RakeTask.stub :find_by_id, mock_find_by_id do
       post "/rake-ui/rake_tasks/#{mock_task.id}/execute", params: { environment: "FOO=bar",
                                                                     args: "1,2,3" }
+
+      assert_redirected_to "/rake-ui/rake_task_logs/1234_path"
     end
   end
 end


### PR DESCRIPTION
This PR Adds the Concept of a "Rake Task Log" in our system along with associated controller/views to interact with them. 
 - Route for /rake_task_logs 
 - Concept of a normalized file based on the task name that invoked it.  These files act as a quasi database for us and will allow sorting based on task, date, etc without having to maintains something like sqlite
 - Ability to stream a log in real time when you are looking at the results of a file run

Executing and Navigating Tasks/Logs
![Peek 2021-02-05 08-34](https://user-images.githubusercontent.com/1709860/107047092-0b25ac00-678d-11eb-9899-ca84e70b888c.gif)


File Structure
![image](https://user-images.githubusercontent.com/1709860/106984852-eea65700-672d-11eb-85a3-a5e6ddfa0e53.png)

File Content
![image](https://user-images.githubusercontent.com/1709860/106984919-15fd2400-672e-11eb-8a5b-325e6c4cfd41.png)
