### PR TITLE
Allow running the UI in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0]
+
+* Adds `allow_production` configuration option
+
 ## [0.0.1]
 * Setup CI and Gem Publishing, add better form Validations
   [#10](https://github.com/doximity/rake-ui/pull/10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rake-ui (0.0.1)
+    rake-ui (0.1.0)
       actionpack
       activesupport
       railties
@@ -183,4 +183,4 @@ DEPENDENCIES
   standardrb
 
 BUNDLED WITH
-   2.2.8
+   2.2.14

--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ NOTE: Relative to mountpoint in application
 Add this line to your application's Gemfile:
 
 ```ruby
-group :development do 
-  gem 'rake-ui'
-end
+gem 'rake-ui'
 ```
 
 And then execute:
@@ -46,7 +44,13 @@ end
 
 This tool is built to enable developer productivity in development.  It exposes rake tasks through a UI.
 
-This tool will currently not work in production because we add a guard in the root controller to respond not found if the environment is development or test.  
+This tool will currently not work in production because we add a guard in the root controller to respond not found if the environment is development or test. You may override this guard clause with the following configuration.
+
+```rb
+RakeUi.configuration do |config|
+  config.allow_production = true
+end
+```
 
 We recommend adding guards in your route to ensure that the proper authentication is in place to ensure that users are authenticated so that if this were ever to be rendered in production, you would be covered.  The best way for that is [router constraints](https://guides.rubyonrails.org/routing.html#specifying-constraints)
 

--- a/app/controllers/rake_ui/application_controller.rb
+++ b/app/controllers/rake_ui/application_controller.rb
@@ -7,7 +7,9 @@ module RakeUi
     private
 
     def black_hole_production
-      raise ActionController::RoutingError, "Not Found" unless Rails.env.test? || Rails.env.development?
+      return if Rails.env.test? || Rails.env.development? || RakeUi.configuration.allow_production
+
+      raise ActionController::RoutingError, "Not Found"
     end
   end
 end

--- a/lib/rake-ui.rb
+++ b/lib/rake-ui.rb
@@ -3,4 +3,11 @@
 require "rake-ui/engine"
 
 module RakeUi
+  mattr_accessor :allow_production
+  self.allow_production = false
+
+  def self.configuration
+    yield(self) if block_given?
+    self
+  end
 end

--- a/lib/rake-ui/version.rb
+++ b/lib/rake-ui/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RakeUi
-  VERSION = "0.0.1"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
Adds an `allow_production` configuration option.

@Austio I did this pretty quickly and tested locally. Let me know if there are any other changes you'd like to see here.