### PR TITLE
Prevent `InvalidAuthenticityToken` & Infinite Loop

### DIFF
--- a/app/controllers/rake_ui/application_controller.rb
+++ b/app/controllers/rake_ui/application_controller.rb
@@ -3,6 +3,7 @@
 module RakeUi
   class ApplicationController < ActionController::Base
     before_action :black_hole_production
+    skip_before_action :verify_authenticity_token
 
     private
 

--- a/app/controllers/rake_ui/rake_tasks_controller.rb
+++ b/app/controllers/rake_ui/rake_tasks_controller.rb
@@ -11,8 +11,6 @@ module RakeUi
       :is_internal_task,
       :sources].freeze
 
-    skip_before_action :verify_authenticity_token
-
     def index
       @rake_tasks = RakeUi::RakeTask.all
 

--- a/app/controllers/rake_ui/rake_tasks_controller.rb
+++ b/app/controllers/rake_ui/rake_tasks_controller.rb
@@ -11,6 +11,8 @@ module RakeUi
       :is_internal_task,
       :sources].freeze
 
+    skip_before_action :verify_authenticity_token
+
     def index
       @rake_tasks = RakeUi::RakeTask.all
 

--- a/app/models/rake_ui/rake_task_log.rb
+++ b/app/models/rake_ui/rake_task_log.rb
@@ -112,10 +112,6 @@ module RakeUi
       super || parsed_file_contents[:log_file_name]
     end
 
-    def log_file_full_path
-      super || parsed_file_contents[:log_file_full_path]
-    end
-
     def rake_command_with_logging
       "#{rake_command} 2>&1 >> #{log_file_full_path}"
     end
@@ -151,8 +147,7 @@ module RakeUi
     #
     # { name: 'foo', id: 'baz' }
     def parsed_file_contents
-      return @parsed_file_contents if defined?(@parsed_file_contents)
-      return {} unless log_file_full_path
+      return @parsed_file_contents if defined? @parsed_file_contents
 
       @parsed_file_contents = {}.tap do |parsed|
         File.foreach(log_file_full_path).first(9).each do |line|

--- a/app/models/rake_ui/rake_task_log.rb
+++ b/app/models/rake_ui/rake_task_log.rb
@@ -151,7 +151,8 @@ module RakeUi
     #
     # { name: 'foo', id: 'baz' }
     def parsed_file_contents
-      return @parsed_file_contents if defined? @parsed_file_contents
+      return @parsed_file_contents if defined?(@parsed_file_contents)
+      return {} unless log_file_full_path
 
       @parsed_file_contents = {}.tap do |parsed|
         File.foreach(log_file_full_path).first(9).each do |line|


### PR DESCRIPTION
`skip_before_action :verify_authenticity_token` prevents the `InvalidAuthenticityToken` while running this behind a reverse proxy.  Since it is only used for `development` environments, I don't think there is much risk for doing this.

Removing `log_file_full_path` prevents an infinite loop I was seeing when running via docker container.  

```
rake-ui (1d3779ffd621) app/models/rake_ui/rake_task_log.rb:156:in `parsed_file_contents'
rake-ui (1d3779ffd621) app/models/rake_ui/rake_task_log.rb:116:in `log_file_full_path'
rake-ui (1d3779ffd621) app/models/rake_ui/rake_task_log.rb:157:in `block in parsed_file_contents'
<internal:kernel>:90:in `tap'
rake-ui (1d3779ffd621) app/models/rake_ui/rake_task_log.rb:156:in `parsed_file_contents'
rake-ui (1d3779ffd621) app/models/rake_ui/rake_task_log.rb:116:in `log_file_full_path'
rake-ui (1d3779ffd621) app/models/rake_ui/rake_task_log.rb:157:in `block in parsed_file_contents'
 <internal:kernel>:90:in `tap'