### PR TITLE
test for staging env acceptability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /test/dummy/tmp/development_secret.txt
 
 .byebug_history
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ RakeUi.configuration do |config|
   config.allow_production = true
 end
 ```
+The `staging` environment will be available by default.  If you determine this is a risk, you can disable that.
+```rb
+RakeUi.configuration do |config|
+  config.allow_staging = false
+end
+```
+
 
 We recommend adding guards in your route to ensure that the proper authentication is in place to ensure that users are authenticated so that if this were ever to be rendered in production, you would be covered.  The best way for that is [router constraints](https://guides.rubyonrails.org/routing.html#specifying-constraints)
 

--- a/app/controllers/rake_ui/application_controller.rb
+++ b/app/controllers/rake_ui/application_controller.rb
@@ -4,10 +4,13 @@ module RakeUi
   class ApplicationController < ActionController::Base
     before_action :black_hole_production
 
+    STAGING_OK = (Rails.env.staging? && RakeUi.configuration.allow_staging)
+    PROD_OK = RakeUi.configuration.allow_production
+
     private
 
     def black_hole_production
-      return if Rails.env.test? || Rails.env.development? || RakeUi.configuration.allow_production
+      return if Rails.env.test? || Rails.env.development? || STAGING_OK || PROD_OK
 
       raise ActionController::RoutingError, "Not Found"
     end

--- a/lib/rake-ui.rb
+++ b/lib/rake-ui.rb
@@ -4,7 +4,10 @@ require "rake-ui/engine"
 
 module RakeUi
   mattr_accessor :allow_production
+  mattr_accessor :allow_staging
+
   self.allow_production = false
+  self.allow_staging = true
 
   def self.configuration
     yield(self) if block_given?


### PR DESCRIPTION
I found that the gem would not run on the `staging` env.  

This adds another config to allow for that. 